### PR TITLE
[202405] Added debug retry mechanism for docker command in warm reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -439,8 +439,13 @@ function check_docker_exec() {
                 fi
                 success=true
                 break
-             else
+	      elif [[ x"${STATE}" == x"timed out" ]]; then
+                # docker exec timed out
                  error "docker exec timed out for $container for $timeout_duration"
+             else
+                # Timeout is the only cause of failure, if docker is down then exit out of loop
+                success=true
+                break
              fi
              timeout_duration=$((timeout_duration + 1))
          done

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -424,16 +424,31 @@ function setup_reboot_variables()
     fi
 }
 
-function check_docker_exec()
-{
-    containers="radv bgp lldp swss database teamd syncd"
-    for container in $containers; do
-        STATE=$(timeout 1s docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
-        if [[ x"${STATE}" == x"timed out" ]]; then
-            error "Docker exec on $container timedout"
-            exit "${EXIT_FAILURE}"
-        fi
-    done
+function check_docker_exec() {
+     containers="radv bgp lldp swss database teamd syncd"
+     for container in $containers; do
+         local timeout_duration=1
+         local max_timeout=5
+         local success=false
+         while [[ $timeout_duration -le $max_timeout ]]; do
+             STATE=$(timeout ${timeout_duration}s docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
+             if [[ x"${STATE}" == x"success" ]]; then
+                if [[ $timeout_duration -ge 2 ]]; then
+                    error "Docker exec on $container succeeded only after $timeout_duration tries"
+                    exit "${EXIT_FAILURE}"
+                fi
+                success=true
+                break
+             else
+                 error "docker exec timed out for $container for $timeout_duration"
+             fi
+             timeout_duration=$((timeout_duration + 1))
+         done
+         if [[ $success == false ]]; then
+            error "Docker exec on $container timed out after ${max_timeout}s"
+             exit "${EXIT_FAILURE}"
+         fi
+     done
 }
 
 function check_db_integrity()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Since warm-reboot command is failing for some tests, added retry mechanism for docker exec command in the script so that the warm-reboot does not fail
#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

