### PR TITLE
[202411] Added retry for docker execution

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -486,53 +486,6 @@ def show():
 
     click.echo(tabulate(data, headers=header, tablefmt="simple", missingval=""))
 
-def _update_config_db_flex_counter_table(status, filename):
-    """ Update counter configuration in config_db file """
-    with open(filename) as config_db_file:
-        config_db = json.load(config_db_file)
-
-    write_config_db = False
-    if "FLEX_COUNTER_TABLE" in config_db:
-        if status != "delay":
-            for counter, counter_config in config_db["FLEX_COUNTER_TABLE"].items():
-                if "FLEX_COUNTER_STATUS" in counter_config and \
-                    counter_config["FLEX_COUNTER_STATUS"] is not status:
-                    counter_config["FLEX_COUNTER_STATUS"] = status
-                    write_config_db = True
-
-        elif status == "delay":
-            write_config_db = True
-            for key in config_db["FLEX_COUNTER_TABLE"].keys():
-                config_db["FLEX_COUNTER_TABLE"][key].update({"FLEX_COUNTER_DELAY_STATUS":"true"})
-
-    if write_config_db:
-        with open(filename, 'w') as config_db_file:
-            json.dump(config_db, config_db_file, indent=4)
-
-# Working on Config DB
-@cli.group()
-def config_db():
-    """ Config DB counter commands """
-
-@config_db.command()
-@click.argument("filename", default="/etc/sonic/config_db.json", type=click.Path(exists=True))
-def enable(filename):
-    """ Enable counter configuration in config_db file """
-    _update_config_db_flex_counter_table("enable", filename)
-
-@config_db.command()
-@click.argument("filename", default="/etc/sonic/config_db.json", type=click.Path(exists=True))
-def disable(filename):
-    """ Disable counter configuration in config_db file """
-    _update_config_db_flex_counter_table("disable", filename)
-
-@config_db.command()
-@click.argument("filename", default="/etc/sonic/config_db.json", type=click.Path(exists=True))
-def delay(filename):
-    """ Delay counters in config_db file """
-    _update_config_db_flex_counter_table("delay", filename)
-
-
 """
 The list of dynamic commands that are added on a specific condition.
 Format:

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -59,7 +59,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_202411_01'
+        self.CURRENT_VERSION = 'version_202411_02'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -857,6 +857,17 @@ class DBMigrator():
             if keys:
                 self.configDB.delete(self.configDB.CONFIG_DB, authorization_key)
 
+    def migrate_flex_counter_delay_status_removal(self):
+        """
+        Remove FLEX_COUNTER_DELAY_STATUS field.
+        """
+
+        flex_counter_objects = self.configDB.get_keys('FLEX_COUNTER_TABLE')
+        for obj in flex_counter_objects:
+            flex_counter = self.configDB.get_entry('FLEX_COUNTER_TABLE', obj)
+            flex_counter.pop('FLEX_COUNTER_DELAY_STATUS', None)
+            self.configDB.set_entry('FLEX_COUNTER_TABLE', obj, flex_counter)
+
     def version_unknown(self):
         """
         version_unknown tracks all SONiC versions that doesn't have a version
@@ -1237,10 +1248,19 @@ class DBMigrator():
 
     def version_202411_01(self):
         """
-        Version 202411_01, this version should be the final version for
-        master branch until 202411 branch is created.
+        Version 202411_01.
         """
         log.log_info('Handling version_202411_01')
+        self.migrate_flex_counter_delay_status_removal()
+        self.set_version('version_202411_02')
+        return 'version_202411_02'
+
+    def version_202411_02(self):
+        """
+        Version 202411_02
+        This is current last version for 202411 branch
+        """
+        log.log_info('Handling version_202411_02')
         return None
 
     def get_version(self):

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -475,7 +475,7 @@ function check_docker_exec()
         for ((i=1; i<=max_retries; i++)); do
             STATE=$(timeout $timeout docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
             if [[ x"${STATE}" != x"timed out" ]]; then
-                debug "docker exec for $container succeeeded in $i tries"
+                debug "docker exec for $container succeeded in $i tries"
                 success=true
                 break
             fi

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -469,10 +469,20 @@ function setup_reboot_variables()
 function check_docker_exec()
 {
     containers="radv bgp lldp swss database teamd syncd"
+    timeout=1s
+    max_retries=5
     for container in $containers; do
-        STATE=$(timeout 1s docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
-        if [[ x"${STATE}" == x"timed out" ]]; then
-            error "Docker exec on $container timedout"
+        success=false
+        for ((i=1; i<=max_retries; i++)); do
+            STATE=$(timeout $timeout docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
+            if [[ x"${STATE}" != x"timed out" ]]; then
+                debug "docker exec for $container succeeeded in $i tries"
+                success=true
+                break
+            fi
+        done
+        if [[ $success == false ]]; then
+            error "Docker exec on $container timed out after $max_retries retries"
             exit "${EXIT_FAILURE}"
         fi
     done

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -44,7 +44,6 @@ EXIT_FILE_SYSTEM_FULL=3
 EXIT_NEXT_IMAGE_NOT_EXISTS=4
 EXIT_ORCHAGENT_SHUTDOWN=10
 EXIT_SYNCD_SHUTDOWN=11
-EXIT_COUNTERPOLL_DELAY_FAILURE=14
 EXIT_DB_INTEGRITY_FAILURE=15
 EXIT_NO_CONTROL_PLANE_ASSISTANT=20
 EXIT_SONIC_INSTALLER_VERIFY_REBOOT=21
@@ -776,17 +775,6 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" || "$
         else
             exit "${EXIT_ORCHAGENT_SHUTDOWN}"
         fi
-    fi
-fi
-
-if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
-    COUNTERPOLL_DELAY_RC=0
-    # Delay counters in config_db.json
-    /usr/local/bin/counterpoll config-db delay $CONFIG_DB_FILE || COUNTERPOLL_DELAY_RC=$?
-    if [[ COUNTERPOLL_DELAY_RC -ne 0 ]]; then
-        error "Failed to delay counterpoll. Exit code: $COUNTERPOLL_DELAY_RC"
-        unload_kernel
-        exit "${EXIT_COUNTERPOLL_DELAY_FAILURE}"
     fi
 fi
 

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -110,18 +110,6 @@ class TestCounterpoll(object):
         os.remove(config_db_file)
 
     @pytest.mark.parametrize("status", ["disable", "enable"])
-    def test_update_counter_config_db_status(self, status, _get_config_db_file):
-        runner = CliRunner()
-        result = runner.invoke(counterpoll.cli.commands["config-db"].commands[status], [_get_config_db_file])
-
-        with open(_get_config_db_file) as json_file:
-            config_db = json.load(json_file)
-
-        if "FLEX_COUNTER_TABLE" in config_db:
-            for counter, counter_config in config_db["FLEX_COUNTER_TABLE"].items():
-                assert counter_config["FLEX_COUNTER_STATUS"] == status
-
-    @pytest.mark.parametrize("status", ["disable", "enable"])
     def test_update_pg_drop_status(self, status):
         runner = CliRunner()
         db = Db()

--- a/tests/db_migrator_input/config_db/cross_branch_upgrade_to_4_0_3_expected.json
+++ b/tests/db_migrator_input/config_db/cross_branch_upgrade_to_4_0_3_expected.json
@@ -4,16 +4,13 @@
     },
     "FLEX_COUNTER_TABLE|ACL": {
         "FLEX_COUNTER_STATUS": "enable",
-        "FLEX_COUNTER_DELAY_STATUS": "true",
         "POLL_INTERVAL": "10000"
     },
     "FLEX_COUNTER_TABLE|QUEUE": {
         "FLEX_COUNTER_STATUS": "enable",
-        "FLEX_COUNTER_DELAY_STATUS": "true",
         "POLL_INTERVAL": "10000"
     },
     "FLEX_COUNTER_TABLE|PG_WATERMARK": {
-        "FLEX_COUNTER_STATUS": "disable",
-        "FLEX_COUNTER_DELAY_STATUS": "true"
+        "FLEX_COUNTER_STATUS": "disable"
     }
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added retry for `docker exec` since there are failures on systems after utilization increased from previous releases during warm-reboot exeution

#### How I did it
Added retry mechanism in the bash script, if there is a failure there are 5 retries attempted for the docker exec command

#### How to verify it
Run `warm-reboot` command


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

