### PR TITLE
[Mellanox][Smartswitch]Added dpu status output

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1343,6 +1343,7 @@ collect_mellanox() {
     local platform=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_platform())")
     local platform_folder="/usr/share/sonic/device/${platform}"
     local hwsku=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_hwsku())")
+    local is_smartswitch=$(python3 -c "from sonic_py_common import device_info; print(device_info.is_smartswitch())")
     local sku_folder="/usr/share/sonic/device/${platform}/${hwsku}"
     local cmis_host_mgmt_files=(
         "/tmp/nv-syncd-shared/sai.profile"
@@ -1404,6 +1405,9 @@ collect_mellanox() {
     fi
 
     save_cmd "get_component_versions.py" "component_versions"
+    if [[ $is_smartswitch == "True" ]]; then
+        save_cmd "dpuctl dpu-status" "dpu_status"
+    fi
 
     # Save CMIS-host-management related files
     local cmis_host_mgmt_path="cmis-host-mgmt"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add output for `dpuctl dpu-status` for mellanox specific smartswitch devices in the generate_dump command

#### How I did it
Add `save_cmd` output for `dpuctl dpu-status` it will be written to `dpu_status` file as part of the dump

#### How to verify it
Generate dump using `show techsupport` command and checked the output to see if the `dpu_status` file is created

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

