### PR TITLE
Fix multi asic connector creation

### DIFF
--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -1119,3 +1119,74 @@ class TestMultiAsicPortStat(object):
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
         os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
         remove_tmp_cnstat_file()
+
+
+class TestPortstatGetDbClient(object):
+    """Test the get_db_client method for caching DB connections"""
+
+    def test_get_db_client_creates_new_connection(self):
+        """Test that get_db_client creates a new connection when none exists"""
+        from unittest import mock
+        from utilities_common.portstat import Portstat
+        from utilities_common.constants import DEFAULT_NAMESPACE
+
+        portstat = Portstat(namespace=DEFAULT_NAMESPACE, display_option='')
+
+        with mock.patch('sonic_py_common.multi_asic.connect_to_all_dbs_for_ns') as mock_connect:
+            mock_db_client = mock.MagicMock()
+            mock_connect.return_value = mock_db_client
+
+            result = portstat.get_db_client('asic0')
+
+            mock_connect.assert_called_once_with('asic0')
+
+            assert result == mock_db_client
+
+            assert portstat.db_clients['asic0'] == mock_db_client
+
+    def test_get_db_client_returns_cached_connection(self):
+        """Test that get_db_client returns cached connection on subsequent calls"""
+        from unittest import mock
+        from utilities_common.portstat import Portstat
+        from utilities_common.constants import DEFAULT_NAMESPACE
+
+        portstat = Portstat(namespace=DEFAULT_NAMESPACE, display_option='')
+
+        with mock.patch('sonic_py_common.multi_asic.connect_to_all_dbs_for_ns') as mock_connect:
+            mock_db_client = mock.MagicMock()
+            mock_connect.return_value = mock_db_client
+            result1 = portstat.get_db_client('asic0')
+            result2 = portstat.get_db_client('asic0')
+            mock_connect.assert_called_once_with('asic0')
+
+            assert result1 == result2
+            assert result1 == mock_db_client
+
+    def test_get_db_client_multiple_namespaces(self):
+        """Test that get_db_client handles multiple namespaces correctly"""
+        from unittest import mock
+        from utilities_common.portstat import Portstat
+        from utilities_common.constants import DEFAULT_NAMESPACE
+
+        portstat = Portstat(namespace=DEFAULT_NAMESPACE, display_option='')
+
+        with mock.patch('sonic_py_common.multi_asic.connect_to_all_dbs_for_ns') as mock_connect:
+            mock_db_client_asic0 = mock.MagicMock()
+            mock_db_client_asic1 = mock.MagicMock()
+
+            def side_effect(ns):
+                if ns == 'asic0':
+                    return mock_db_client_asic0
+                elif ns == 'asic1':
+                    return mock_db_client_asic1
+
+            mock_connect.side_effect = side_effect
+            result_asic0 = portstat.get_db_client('asic0')
+            result_asic1 = portstat.get_db_client('asic1')
+            assert mock_connect.call_count == 2
+            mock_connect.assert_any_call('asic0')
+            mock_connect.assert_any_call('asic1')
+            assert result_asic0 == mock_db_client_asic0
+            assert result_asic1 == mock_db_client_asic1
+            assert portstat.db_clients['asic0'] == mock_db_client_asic0
+            assert portstat.db_clients['asic1'] == mock_db_client_asic1

--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -166,7 +166,7 @@ class Portstat(object):
         if device_info.is_supervisor():
             self.db = SonicV2Connector(use_unix_socket_path=False)
             self.db.connect(self.db.CHASSIS_STATE_DB, False)
-
+        self.db_clients = {}
         self.sorted = natsorted
 
     def get_cnstat_dict(self):
@@ -370,7 +370,7 @@ class Portstat(object):
         state_db_table_id = PORT_STATE_TABLE_PREFIX + port_name
         app_db_table_id = PORT_STATUS_TABLE_PREFIX + port_name
         for ns in self.multi_asic.get_ns_list_based_on_options():
-            self.db = multi_asic.connect_to_all_dbs_for_ns(ns)
+            self.db = self.get_db_client(ns)
             speed = self.db.get(self.db.STATE_DB, state_db_table_id, PORT_SPEED_FIELD)
             oper_status = self.db.get(self.db.APPL_DB, app_db_table_id, PORT_OPER_STATUS_FIELD)
             if speed is None or speed == STATUS_NA or oper_status != "up":
@@ -378,6 +378,11 @@ class Portstat(object):
             if speed is not None:
                 return int(speed)
         return STATUS_NA
+
+    def get_db_client(self, ns):
+        if not self.db_clients.get(ns):
+            self.db_clients[ns] = multi_asic.connect_to_all_dbs_for_ns(ns)
+        return self.db_clients[ns]
 
     def get_port_state(self, port_name):
         """
@@ -392,7 +397,7 @@ class Portstat(object):
 
         full_table_id = PORT_STATUS_TABLE_PREFIX + port_name
         for ns in self.multi_asic.get_ns_list_based_on_options():
-            self.db = multi_asic.connect_to_all_dbs_for_ns(ns)
+            self.db = self.get_db_client(ns)
             admin_state = self.db.get(self.db.APPL_DB, full_table_id, PORT_ADMIN_STATUS_FIELD)
             oper_state = self.db.get(self.db.APPL_DB, full_table_id, PORT_OPER_STATUS_FIELD)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Create a cache for the SonicV2Connector objects which are created, because currently we are creating n interfaces * m namespace amount of connectors in case of multi asic implementation, which is very high and would lead to the `show interface counters` command to crash
```
root@sonic:/home/admin# show interfaces counters
Traceback (most recent call last):
  File "/usr/local/bin/portstat", line 168, in 
    main()
  File "/usr/local/bin/portstat", line 158, in main
    portstat.cnstat_diff_print(cnstat_dict, {}, ratestat_dict, intf_list, use_json, print_all, errors_only,
  File "/usr/local/lib/python3.11/dist-packages/utilities_common/portstat.py", line 572, in cnstat_diff_print
    port_speed = self.get_port_speed(key)
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/utilities_common/portstat.py", line 373, in get_port_speed
    self.db = multi_asic.connect_to_all_dbs_for_ns(ns)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/sonic_py_common/multi_asic.py", line 81, in connect_to_all_dbs_for_ns
    db.connect(db_id)
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2069, in connect
    return _swsscommon.SonicV2Connector_Native_connect(self, db_name, retry_on)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Unable to connect to redis - Cannot assign requested address(1): Cannot assign requested address
```
#### How I did it
Cache the connectors in a dictionary

#### How to verify it
Run `show interfaces counters` command

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

