### PR TITLE
Fix multi asic initialization for dump command 

### DIFF
--- a/dump/main.py
+++ b/dump/main.py
@@ -7,7 +7,7 @@ from tabulate import tabulate
 from sonic_py_common import multi_asic
 from utilities_common.constants import DEFAULT_NAMESPACE
 from dump.match_infra import RedisSource, JsonSource, MatchEngine, CONN
-from swsscommon.swsscommon import ConfigDBConnector
+from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig
 from dump import plugins
 
 # Autocompletion Helper
@@ -31,6 +31,8 @@ def show_modules(ctx, param, value):
 @click.pass_context
 def dump(ctx):
     ctx.obj = MatchEngine()
+    if multi_asic.is_multi_asic() and not SonicDBConfig.isGlobalInit():
+        SonicDBConfig.initializeGlobalConfig()
 
 
 @dump.command()

--- a/dump/main.py
+++ b/dump/main.py
@@ -31,8 +31,6 @@ def show_modules(ctx, param, value):
 @click.pass_context
 def dump(ctx):
     ctx.obj = MatchEngine()
-    if multi_asic.is_multi_asic() and not SonicDBConfig.isGlobalInit():
-        SonicDBConfig.initializeGlobalConfig()
 
 
 @dump.command()
@@ -62,6 +60,9 @@ def state(ctx, module, identifier, db, table, key_map, verbose, namespace):
     if multi_asic.is_multi_asic() and (namespace != DEFAULT_NAMESPACE and namespace not in multi_asic.get_namespace_list()):
         click.echo("Namespace option is not valid. Choose one of {}".format(multi_asic.get_namespace_list()))
         ctx.exit()
+
+    if multi_asic.is_multi_asic() and not SonicDBConfig.isGlobalInit():
+        SonicDBConfig.initializeGlobalConfig()
 
     if module not in plugins.dump_modules:
         click.echo("No Matching Plugin has been Implemented")

--- a/tests/dump_tests/dump_state_test.py
+++ b/tests/dump_tests/dump_state_test.py
@@ -337,3 +337,44 @@ class TestDumpStateMultiAsic(object):
         result = runner.invoke(dump.state, ["port", "Ethernet0", "--namespace", "asic3"], obj=match_engine_masic)
         assert result.output == "Namespace option is not valid. Choose one of ['asic0', 'asic1']\n", result
 
+class TestMultiAsicInit:
+    """Test multi-asic initialization in dump command group"""
+
+    @mock.patch('dump.plugins.dump_modules', {})
+    @mock.patch('dump.main.SonicDBConfig')
+    @mock.patch('dump.main.multi_asic')
+    def test_multi_asic_global_config_init(self, mock_multi_asic, mock_sonic_db_config):
+        """Test that SonicDBConfig.initializeGlobalConfig() is called when multi-asic and not initialized"""
+        mock_multi_asic.is_multi_asic.return_value = True
+        mock_sonic_db_config.isGlobalInit.return_value = False
+        runner = CliRunner()
+        result = runner.invoke(dump.state, ['port', 'Ethernet0'])
+        mock_multi_asic.is_multi_asic.assert_called()
+        mock_sonic_db_config.isGlobalInit.assert_called()
+        mock_sonic_db_config.initializeGlobalConfig.assert_called_once()
+
+    @mock.patch('dump.plugins.dump_modules', {})
+    @mock.patch('dump.main.SonicDBConfig')
+    @mock.patch('dump.main.multi_asic')
+    def test_multi_asic_already_initialized(self, mock_multi_asic, mock_sonic_db_config):
+        """Test that initializeGlobalConfig() is NOT called when already initialized"""
+        mock_multi_asic.is_multi_asic.return_value = True
+        mock_sonic_db_config.isGlobalInit.return_value = True
+        runner = CliRunner()
+        result = runner.invoke(dump.state, ['port', 'Ethernet0'])
+        mock_multi_asic.is_multi_asic.assert_called()
+        mock_sonic_db_config.isGlobalInit.assert_called()
+        mock_sonic_db_config.initializeGlobalConfig.assert_not_called()
+
+    @mock.patch('dump.plugins.dump_modules', {})
+    @mock.patch('dump.main.SonicDBConfig')
+    @mock.patch('dump.main.multi_asic')
+    def test_single_asic_no_init(self, mock_multi_asic, mock_sonic_db_config):
+        """Test that initializeGlobalConfig() is NOT called on single-asic systems"""
+        mock_multi_asic.is_multi_asic.return_value = False
+        runner = CliRunner()
+        result = runner.invoke(dump.state, ['port', 'Ethernet0'])
+        mock_multi_asic.is_multi_asic.assert_called()
+        mock_sonic_db_config.isGlobalInit.assert_not_called()
+        mock_sonic_db_config.initializeGlobalConfig.assert_not_called()
+

--- a/tests/dump_tests/dump_state_test.py
+++ b/tests/dump_tests/dump_state_test.py
@@ -337,6 +337,7 @@ class TestDumpStateMultiAsic(object):
         result = runner.invoke(dump.state, ["port", "Ethernet0", "--namespace", "asic3"], obj=match_engine_masic)
         assert result.output == "Namespace option is not valid. Choose one of ['asic0', 'asic1']\n", result
 
+
 class TestMultiAsicInit:
     """Test multi-asic initialization in dump command group"""
 
@@ -348,7 +349,7 @@ class TestMultiAsicInit:
         mock_multi_asic.is_multi_asic.return_value = True
         mock_sonic_db_config.isGlobalInit.return_value = False
         runner = CliRunner()
-        result = runner.invoke(dump.state, ['port', 'Ethernet0'])
+        runner.invoke(dump.state, ['port', 'Ethernet0'])
         mock_multi_asic.is_multi_asic.assert_called()
         mock_sonic_db_config.isGlobalInit.assert_called()
         mock_sonic_db_config.initializeGlobalConfig.assert_called_once()
@@ -361,7 +362,7 @@ class TestMultiAsicInit:
         mock_multi_asic.is_multi_asic.return_value = True
         mock_sonic_db_config.isGlobalInit.return_value = True
         runner = CliRunner()
-        result = runner.invoke(dump.state, ['port', 'Ethernet0'])
+        runner.invoke(dump.state, ['port', 'Ethernet0'])
         mock_multi_asic.is_multi_asic.assert_called()
         mock_sonic_db_config.isGlobalInit.assert_called()
         mock_sonic_db_config.initializeGlobalConfig.assert_not_called()
@@ -373,7 +374,7 @@ class TestMultiAsicInit:
         """Test that initializeGlobalConfig() is NOT called on single-asic systems"""
         mock_multi_asic.is_multi_asic.return_value = False
         runner = CliRunner()
-        result = runner.invoke(dump.state, ['port', 'Ethernet0'])
+        runner.invoke(dump.state, ['port', 'Ethernet0'])
         mock_multi_asic.is_multi_asic.assert_called()
         mock_sonic_db_config.isGlobalInit.assert_not_called()
         mock_sonic_db_config.initializeGlobalConfig.assert_not_called()

--- a/tests/dump_tests/dump_state_test.py
+++ b/tests/dump_tests/dump_state_test.py
@@ -378,4 +378,3 @@ class TestMultiAsicInit:
         mock_multi_asic.is_multi_asic.assert_called()
         mock_sonic_db_config.isGlobalInit.assert_not_called()
         mock_sonic_db_config.initializeGlobalConfig.assert_not_called()
-


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
To add initializeGlobalConfig for dump command in case of multi asic implementation, This si to prevent the error:
```
root@dut:/home/admin# dump state interface Ethernet0 -n asic0
Traceback (most recent call last):
  File "/usr/local/bin/dump", line 8, in <module>
    sys.exit(dump())
             ^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/dump/main.py", line 96, in state
    collected_info = populate_fv(collected_info, module, namespace, ctx.obj.conn_pool, obj.return_pb2_obj())
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/dump/main.py", line 159, in populate_fv
    conn_pool.get(db_name, namespace)
  File "/usr/local/lib/python3.11/dist-packages/dump/match_infra.py", line 316, in get
    self.cache[ns][CONN] = self.initialize_connector(ns)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/dump/match_infra.py", line 298, in initialize_connector
    return SonicV2Connector(namespace=ns, use_unix_socket_path=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2138, in __init__
    for db_name in self.get_db_list():
                   ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2075, in get_db_list
    return _swsscommon.SonicV2Connector_Native_get_db_list(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: :- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig
```
On multi asic system

#### How I did it
Initializae global config

#### How to verify it
Run unit test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

